### PR TITLE
Adding in check_group_membership to launch script

### DIFF
--- a/maynard.in
+++ b/maynard.in
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 PREFIX=@prefix@
 LIBEXECDIR=$PREFIX/libexec
@@ -19,6 +19,30 @@ check_install() {
     fi
 }
 
+check_group_membership() {
+        group_membership=$(groups $USER);
+        if [[ $group_membership != *weston-launch* ]]; then
+            echo "Missing weston-launch group membership for $USER. Try"
+            echo ""
+        echo "    sudo adduser $USER weston-launch"
+            echo ""
+            exit 1
+        fi
+        if [[ $group_membership != *video* ]]; then
+            echo "Missing video group membership for $USER. Try"
+            echo ""
+            echo "    sudo adduser $USER video"
+            echo ""
+            exit 1 
+        fi
+        if [[ $group_membership != *audio* ]]; then
+            echo "Missing audio group membership for $USER. Try"
+            echo ""
+            echo "    sudo adduser $USER audio"
+            exit 1 
+        fi
+    }   
+
 mkdir ~/.config > /dev/null 2>&1
 
 xdpyinfo > /dev/null 2>&1
@@ -34,5 +58,6 @@ if [ "$?" = "0" ]; then
         exit 1
     fi
 else
+    check_group_membership
     weston-launch
 fi


### PR DESCRIPTION
I've added a simple check in the startup script to see if the logged in user is in the following groups
- weston-launch
- video
- audio

This prevents the human hostile errors of weston failing to launch properly because of security restrictions. This approach is generally debian friendly but has only be tested in the Raspberry Pi. Other Unix may use other permissions. 
