### PR TITLE
Drop hardcoded dependency on a wallpaper

### DIFF
--- a/maynard.in
+++ b/maynard.in
@@ -3,6 +3,7 @@
 PREFIX=@prefix@
 LIBEXECDIR=$PREFIX/libexec
 ABS_BUILDDIR=@abs_builddir@
+DEFAULT_BACKGROUND=/usr/share/wallpapers/Hanami/contents/images/3872x2592.jpg
 
 md5() {
     cat "$1" 2> /dev/null | md5sum
@@ -20,6 +21,11 @@ check_install() {
 }
 
 mkdir ~/.config > /dev/null 2>&1
+
+if [ -z "${MAYNARD_BACKGROUND+_}" -a \
+     -e "$DEFAULT_BACKGROUND" ]; then
+    export MAYNARD_BACKGROUND="$DEFAULT_BACKGROUND"
+fi
 
 xdpyinfo > /dev/null 2>&1
 if [ "$?" = "0" ]; then

--- a/shell/maynard.c
+++ b/shell/maynard.c
@@ -43,8 +43,6 @@
 
 extern char **environ; /* defined by libc */
 
-#define DEFAULT_BACKGROUND "/usr/share/wallpapers/Hanami/contents/images/3872x2592.jpg"
-
 struct element {
   GtkWidget *window;
   GdkPixbuf *pixbuf;
@@ -576,13 +574,15 @@ background_create (struct desktop *desktop)
   memset (background, 0, sizeof *background);
 
   filename = g_getenv ("BACKGROUND");
-  if (filename == NULL)
-    filename = DEFAULT_BACKGROUND;
-  unscaled_background = gdk_pixbuf_new_from_file (filename, NULL);
+  if (filename)
+    unscaled_background = gdk_pixbuf_new_from_file (filename, NULL);
+  else
+    unscaled_background = gdk_pixbuf_new_from_xpm_data
+        ((const char*[]){"1 1 1 1", "_ c SteelBlue", "_"});
   if (!unscaled_background)
     {
-      g_message ("Could not load background. "
-          "Do you have kdewallpapers installed?");
+      g_message ("Could not load background (%s).",
+          filename ? filename : "built-in");
       exit (EXIT_FAILURE);
     }
 

--- a/shell/maynard.c
+++ b/shell/maynard.c
@@ -573,8 +573,8 @@ background_create (struct desktop *desktop)
   background = malloc (sizeof *background);
   memset (background, 0, sizeof *background);
 
-  filename = g_getenv ("BACKGROUND");
-  if (filename)
+  filename = g_getenv ("MAYNARD_BACKGROUND");
+  if (filename && *filename)
     unscaled_background = gdk_pixbuf_new_from_file (filename, NULL);
   else
     unscaled_background = gdk_pixbuf_new_from_xpm_data


### PR DESCRIPTION
This sets the default to a solid blue color. A custom wallpaper can be used by
starting weston via
`BACKGROUND=/usr/share/wallpapers/Hanami/contents/images/3872x2592.jpg weston`

This fixes #32.
